### PR TITLE
Fixed: Evaluation Accuracy is shown zero[Result value is always zero]

### DIFF
--- a/train/sentence_classifier_trainer.py
+++ b/train/sentence_classifier_trainer.py
@@ -69,7 +69,7 @@ class SCTrainer:
             self.logger.scalar_summary('epoch_loss', np.mean(result), self.curr_epoch)
         else:
             result = np.sum(result, axis=0)
-            result = result[1] / result[0]
+            result = float(result[1] / result[0])
             print("Evaluation Accuracy: {}".format(result))
 
 


### PR DESCRIPTION
Evaluation Accuracy value shown in integer(so the result value is always zero), now showing in float